### PR TITLE
Update maqmap.c

### DIFF
--- a/src/maqmap.c
+++ b/src/maqmap.c
@@ -42,7 +42,7 @@ maqmap_t *maqmap_read_header(gzFile fp)
 	if (mm->format != MAQMAP_FORMAT_NEW) {
 		if (mm->format > 0) {
 			REprintf("** Obsolete map format is detected. Please use 'mapass2maq' command to convert the format.\n");
-			return 0;
+			return 3;
 		}
 		assert(mm->format == MAQMAP_FORMAT_NEW);
 	}


### PR DESCRIPTION
In the previous edit the exit(3) statement was replaced with a return, to comply with R CRAN requirements that the calls to C subroutines should never be able to cause R termination with exit.

Here I'm replacing return 0 with return 3 to have a return value equal to the previous exit code, although this does not seem to be handled by upstream C++ code calling this subroutine