### PR TITLE
Update zroutines.R

### DIFF
--- a/R/zroutines.R
+++ b/R/zroutines.R
@@ -2216,10 +2216,11 @@ densum <- function(vin,bw=5,dw=3,match.wt.f=NULL,return.x=T,from=min(vin),to=max
     storage.mode(step) <- storage.mode(dlength) <- storage.mode(bw) <- storage.mode(dw) <-"integer";
     dout <- .Call("ccdensum",pos,tc,spos,bw,dw,dlength,step);
   } else {
-    dout <- numeric(dlength); storage.mode(dout) <- "double";
-    storage.mode(dlength) <- "integer";
-    #.C("cdensum",n,pos,tc,spos,bw,dw,dlength,step,dout,DUP=F);
-    .C("cdensum",n,pos,tc,spos,bw,dw,dlength,step,dout);
+stop("Please set new.code=T to use the new ccdensum function. The old cdensum is deprecated")
+#    dout <- numeric(dlength); storage.mode(dout) <- "double";
+#    storage.mode(dlength) <- "integer";
+#    #.C("cdensum",n,pos,tc,spos,bw,dw,dlength,step,dout,DUP=F);
+#    .C("cdensum",n,pos,tc,spos,bw,dw,dlength,step,dout);
   }
   
   


### PR DESCRIPTION
Display error message in case new.code is set to FALSE in the densum function. The "new.code" implemented in ccdensum should be used as indicated by Peter K.