### PR TITLE
Fix error message output bugs; typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A unix-flavored OS with R (>= 3.3.0) installed.
 Since version 1.15.4 spp is available on [CRAN](https://CRAN.R-project.org/package=spp) and can be installed using the command
 
 ```
-install.pacakges("spp", dependencies=TRUE)
+install.packages("spp", dependencies=TRUE)
 ```
 
 

--- a/src/bed2vector.cpp
+++ b/src/bed2vector.cpp
@@ -439,9 +439,11 @@ SEXP read_meland_old(SEXP filename) {
 
   
   FILE *f=fopen(fname,"rb");
-  if (!f)  { Rprintf("can't open input file \"",fname,"\"\n"); }
-  
-  Rprintf("opened %s\n",fname);
+  if (!f)  { 
+	  Rprintf("can't open input file \"%s\"\n",fname); 
+  } else { 
+	  Rprintf("opened %s\n",fname);
+  }
 
 
   // read in bed line
@@ -632,9 +634,11 @@ SEXP read_eland_mismatches(SEXP filename) {
 
   
   FILE *f=fopen(fname,"rb");
-  if (!f)  { Rprintf("can't open input file \"",fname,"\"\n"); }
-
-  Rprintf("opened %s\n",fname);
+  if (!f)  { 
+	  Rprintf("can't open input file \"%s\"\n",fname); 
+  } else { 
+	  Rprintf("opened %s\n",fname);
+  }
 
   // read in bed line
   string line;

--- a/src/maqread.cpp
+++ b/src/maqread.cpp
@@ -63,7 +63,7 @@ extern "C" {
   m1 = &mm1;
 
   if (!f)  { 
-    Rprintf("can't open input file \"",fname,"\"\n"); 
+    Rprintf("can't open input file \"%s\"\n",fname);
   }  else {
     Rprintf("opened %s\n",fname);
 


### PR DESCRIPTION
Rprintf was misused causing only the first part of the string to be printed, and in bed2vector.cpp, the success message was printed on failure.

Also merging a typo fix from the master branch.